### PR TITLE
Add option to specify path to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # pollenprognos-card
 A Lovelace custom card for [custom component Pollenprognos](https://github.com/JohNan/homeassistant-pollenprognos) in Home Assistant.
 
-<b>You need to manually move the folder `pollen_img` directly inside your `www` folder for the images to appear.</b>
+<b>You need to manually move the folder `pollen_img` directly inside your `www`
+folder for the images to appear, or set the `img_path` configuration value to
+the prefix of the URL where the images are reachable.</b>
 
 ## Installation
 
@@ -75,6 +77,7 @@ views:
 | title | boolean | **Optional** | Set to `false` to remove the heading from the card
 | show_state | boolean | **Optional** | Set to `false` if you don't want to show the state text under the images.
 | threshold | number | **Optional** | Set to a number if you don't want to show allergens below that number (set to `0` to only exclude unknown or i.u.).
+| img_path | string | **Optional** | The URL prefix for where to find the images; defaults to `"/local/pollen_img"`)
 
 ### Example of the card with all allergens presented
 ![2021-04-23 14_24_23-Admin - Home Assistant](https://user-images.githubusercontent.com/22006797/115870566-b4e91080-a43f-11eb-843e-1f5efbcc2a84.png)

--- a/pollenprognos-card.js
+++ b/pollenprognos-card.js
@@ -69,7 +69,7 @@ class PollenPrognosCard  extends LitElement {
         ${this.sensors.map(sensor => html`
         <div class="sensor">
           <p class="box">${sensor.allergen_locale}</p>
-          <img class="box" src="/local/pollen_img/${sensor.allergens.toLowerCase()}_${sensor.forecast.state == "unknown" || sensor.forecast.state == "i.u." || sensor.forecast.state == "unavailable" ? 0 : sensor.forecast.state}.svg"/>
+          <img class="box" src="/local/pollen_img/${sensor.allergens.toLowerCase()}_${sensor.forecast.state == "-1" || sensor.forecast.state == "unknown" || sensor.forecast.state == "i.u." || sensor.forecast.state == "unavailable" ? 0 : sensor.forecast.state}.svg"/>
           ${this.config.show_state == true || this.config.show_state == null
             ? html`<p class="box">${sensor.forecast.state == "unknown" || sensor.forecast.state == "i.u." ? sensor.forecast.state : this._text(sensor.forecast.state)}</p>`
             : ""}
@@ -136,7 +136,7 @@ class PollenPrognosCard  extends LitElement {
     </style>`
   }
 
-  
+
   _tryParseInt(str,defaultValue) {
     var retValue = defaultValue;
     if(str !== null) {
@@ -149,7 +149,7 @@ class PollenPrognosCard  extends LitElement {
     return retValue;
   }
   set hass(hass) {
-    
+
     this._hass = hass;
     var sensors = [];
 
@@ -168,11 +168,11 @@ class PollenPrognosCard  extends LitElement {
       var dict = {};
       dict.allergen_locale = (allergens[i].charAt(0).toUpperCase() + allergens[i].slice(1));
       var allergen = allergens[i].replace(' / ', '_').toLowerCase();
-      
+
       var allergenReplace = allergen.replace('å', 'a')
       var allergenReplace2 = allergenReplace.replace('ä', 'a')
       var allergenReplaced = allergenReplace2.replace('ö', 'o')
-      
+
       dict.allergens = allergenReplaced
       dict.forecast = hass.states[`sensor.pollen_${city}_${allergenReplaced}`]
       if (dict.forecast.state == "unknown") {

--- a/pollenprognos-card.js
+++ b/pollenprognos-card.js
@@ -69,7 +69,7 @@ class PollenPrognosCard  extends LitElement {
         ${this.sensors.map(sensor => html`
         <div class="sensor">
           <p class="box">${sensor.allergen_locale}</p>
-          <img class="box" src="/local/pollen_img/${sensor.allergens.toLowerCase()}_${sensor.forecast.state == "-1" || sensor.forecast.state == "unknown" || sensor.forecast.state == "i.u." || sensor.forecast.state == "unavailable" ? 0 : sensor.forecast.state}.svg"/>
+          <img class="box" src="${this.img_path}/${sensor.allergens.toLowerCase()}_${sensor.forecast.state == "-1" || sensor.forecast.state == "unknown" || sensor.forecast.state == "i.u." || sensor.forecast.state == "unavailable" ? 0 : sensor.forecast.state}.svg"/>
           ${this.config.show_state == true || this.config.show_state == null
             ? html`<p class="box">${sensor.forecast.state == "unknown" || sensor.forecast.state == "i.u." ? sensor.forecast.state : this._text(sensor.forecast.state)}</p>`
             : ""}
@@ -156,6 +156,12 @@ class PollenPrognosCard  extends LitElement {
     if (this.config.title == null || this.config.title == true) {
       var header_city = this.config.city
       this.header = `Pollenprognos ${header_city.charAt(0).toUpperCase() + header_city.slice(1)}`;
+    }
+
+    if (this.config.img_path != null) {
+      this.img_path = this.config.img_path;
+    } else {
+      this.img_path = "/local/pollen_img";
     }
 
     const cityConf = this.config.city.toLowerCase();


### PR DESCRIPTION
This allows the user to specify a path other than `/local/pollen_img` for the images. 

Also fixes a bug where the no data result (-1, as returned now with no pollen) resultet in no image being shown.